### PR TITLE
Account key export UI/UX improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ WORDS = "abandon abandon abandon abandon abandon abandon abandon abandon abandon
 PIN = 5555
 
 APPNAME = "Cardano ADA"
-APPVERSION = "2.0.0"
+APPVERSION = "2.0.1"
 
 APP_LOAD_PARAMS =--appFlags 0x240 --curve ed25519 --path "44'/1815'" --path "1852'/1815'"
 APP_LOAD_PARAMS += $(COMMON_LOAD_PARAMS)

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ WORDS = "abandon abandon abandon abandon abandon abandon abandon abandon abandon
 PIN = 5555
 
 APPNAME = "Cardano ADA"
-APPVERSION = "2.0.1"
+APPVERSION = "2.0.4"
 
 APP_LOAD_PARAMS =--appFlags 0x240 --curve ed25519 --path "44'/1815'" --path "1852'/1815'"
 APP_LOAD_PARAMS += $(COMMON_LOAD_PARAMS)

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ WORDS = "abandon abandon abandon abandon abandon abandon abandon abandon abandon
 PIN = 5555
 
 APPNAME = "Cardano ADA"
-APPVERSION = "2.0.4"
+APPVERSION = "2.0.5"
 
 APP_LOAD_PARAMS =--appFlags 0x240 --curve ed25519 --path "44'/1815'" --path "1852'/1815'"
 APP_LOAD_PARAMS += $(COMMON_LOAD_PARAMS)

--- a/src/bip44.c
+++ b/src/bip44.c
@@ -6,7 +6,7 @@ static const uint32_t CARDANO_CHAIN_EXTERNAL = 0;
 static const uint32_t CARDANO_CHAIN_INTERNAL = 1;
 static const uint32_t CARDANO_CHAIN_STAKING_KEY = 2;
 
-static const uint32_t MAX_REASONABLE_ACCOUNT = 20;
+static const uint32_t MAX_REASONABLE_ACCOUNT = 100;
 static const uint32_t MAX_REASONABLE_ADDRESS = 1000000;
 
 size_t bip44_parseFromWire(
@@ -39,6 +39,11 @@ bool isHardened(uint32_t value)
 	return value == (value | HARDENED_BIP32);
 }
 
+uint32_t unharden(uint32_t value)
+{
+	ASSERT(isHardened(value));
+	return value & (~HARDENED_BIP32);
+}
 
 // Byron: /44'/1815'
 bool bip44_hasByronPrefix(const bip44_path_t* pathSpec)
@@ -80,14 +85,17 @@ uint32_t bip44_getAccount(const bip44_path_t* pathSpec)
 	return pathSpec->path[BIP44_I_ACCOUNT];
 }
 
+bool bip44_containsMoreThanAccount(const bip44_path_t* pathSpec)
+{
+	return (pathSpec->length > BIP44_I_ACCOUNT + 1);
+}
+
 bool bip44_hasReasonableAccount(const bip44_path_t* pathSpec)
 {
 	if (!bip44_containsAccount(pathSpec)) return false;
 	uint32_t account = bip44_getAccount(pathSpec);
 	if (!isHardened(account)) return false;
-	// Un-harden
-	account = account & (~HARDENED_BIP32);
-	return account < MAX_REASONABLE_ACCOUNT;
+	return unharden(account) <= MAX_REASONABLE_ACCOUNT;
 }
 
 // ChainType
@@ -155,7 +163,7 @@ bool bip44_isValidStakingKeyPath(const bip44_path_t* pathSpec)
 // Futher
 bool bip44_containsMoreThanAddress(const bip44_path_t* pathSpec)
 {
-	return (pathSpec->length > BIP44_I_REST);
+	return (pathSpec->length > BIP44_I_ADDRESS + 1);
 }
 
 

--- a/src/bip44.h
+++ b/src/bip44.h
@@ -38,8 +38,9 @@ bool bip44_hasShelleyPrefix(const bip44_path_t* pathSpec);
 bool bip44_hasValidCardanoPrefix(const bip44_path_t* pathSpec);
 
 bool bip44_containsAccount(const bip44_path_t* pathSpec);
-bool bip44_hasReasonableAccount(const bip44_path_t* pathSpec);
 uint32_t bip44_getAccount(const bip44_path_t* pathSpec);
+bool bip44_containsMoreThanAccount(const bip44_path_t* pathSpec);
+bool bip44_hasReasonableAccount(const bip44_path_t* pathSpec);
 
 bool bip44_containsChainType(const bip44_path_t* pathSpec);
 
@@ -52,6 +53,7 @@ bool bip44_isValidStakingKeyPath(const bip44_path_t* pathSpec);
 bool bip44_containsMoreThanAddress(const bip44_path_t* pathSpec);
 
 bool isHardened(uint32_t value);
+uint32_t unharden(uint32_t value);
 
 void bip44_printToStr(const bip44_path_t*, char* out, size_t outSize);
 

--- a/src/getExtendedPublicKey.c
+++ b/src/getExtendedPublicKey.c
@@ -85,7 +85,7 @@ static void getExtendedPublicKey_ui_runStep()
 		);
 	}
 	UI_STEP(UI_STEP_DISPLAY_PATH) {
-		ui_displayPathScreen("Export public key", &ctx->pathSpec, this_fn);
+		ui_displayAccountScreen("Export public key", &ctx->pathSpec, this_fn);
 	}
 	UI_STEP(UI_STEP_CONFIRM) {
 		ui_displayPrompt(

--- a/src/runTests.c
+++ b/src/runTests.c
@@ -23,6 +23,8 @@ void handleRunTests(
         bool isNewCall MARK_UNUSED
 )
 {
+	// Note: Make sure to have RESET_ON_CRASH flag disabled
+	// as it interferes with tests verifying assertions
 	BEGIN_ASSERT_NOEXCEPT {
 		PRINTF("Running tests\n");
 		run_hex_test();

--- a/src/securityPolicy.c
+++ b/src/securityPolicy.c
@@ -102,7 +102,7 @@ security_policy_t policyForGetExtendedPublicKey(const bip44_path_t* pathSpec)
 
 	WARN_UNLESS(bip44_hasReasonableAccount(pathSpec));
 	// Normally extPubKey is asked only for an account
-	WARN_IF(bip44_containsChainType(pathSpec));
+	WARN_IF(bip44_containsMoreThanAccount(pathSpec));
 
 	PROMPT_IF(true);
 }

--- a/src/signTx.c
+++ b/src/signTx.c
@@ -1006,9 +1006,9 @@ static void signTx_handleWithdrawalAPDU(uint8_t p2, uint8_t* wireDataBuffer, siz
 			};
 
 			deriveAddress(
-				&rewardAddressParams,
-				rewardAddress,
-				SIZEOF(rewardAddress)
+			        &rewardAddressParams,
+			        rewardAddress,
+			        SIZEOF(rewardAddress)
 			);
 		}
 

--- a/src/uiScreens.h
+++ b/src/uiScreens.h
@@ -10,6 +10,12 @@ void ui_displayPathScreen(
         ui_callback_fn_t callback
 );
 
+void ui_displayAccountScreen(
+        const char* screenHeader,
+        const bip44_path_t* path,
+        ui_callback_fn_t callback
+);
+
 void ui_displayAddressScreen(
         const char* screenHeader,
         const uint8_t* addressBuffer, size_t addressSize,


### PR DESCRIPTION
Motivation: Currently the public key export prompt on Ledger is showing to the user just the raw BIP44 path which is not very user-friendly. For account public keys we suggest to show:

* in case of Shelley account public key `Account <account number> <derivation path>`
* in case of Byron accounts: `Byron account <account number> <derivation path>`

Moreover, we are increasing the reasonable account number to 100 since there are plans to add multi account support and the original threshold of 20 was deemed too restrictive. This means that Ledger won't be warning about a suspicious request (be it a public key export or tx signature) for paths related to accounts up to 100. 

Changes:
* update UI message for exporting public keys
* increase reasonable account number from 20 to 100

Testing:
* tested end-to-end with Adalite, works as expected
* integration tests in ledgerjs pass
* device tests pass